### PR TITLE
開発ルールにブランチ管理の手順を追加

### DIFF
--- a/docs/project-knowledge.md
+++ b/docs/project-knowledge.md
@@ -41,6 +41,12 @@
 - PRは1つのチェックボックス（タスク）に対応すること
 - 最後のタスクのPRには「Closes #n」を含めてIssueの自動クローズを設定すること
 
+## ブランチ管理のルール
+- 作業開始前に必ずmainブランチをcheckoutし、最新の状態にする (`git checkout main && git pull origin main`)
+- mainブランチから新しいブランチを作成する (`git checkout -b feature/...`)
+- ブランチ名はConventional Branchに従う
+- 作業完了後、PRを作成する前にmainブランチの最新の変更を取り込む
+
 ## git branch のルール
 - Conventional Branch に従うこと
  - https://conventional-branch.github.io/


### PR DESCRIPTION
## 概要
開発ルールにブランチ管理の手順を追加しました。

## 変更内容
- project-knowledge.mdに「ブランチ管理のルール」セクションを追加
- 以下の内容を記載：
  - 作業開始前に必ずmainブランチをcheckoutし、最新の状態にする (`git checkout main && git pull origin main`)
  - mainブランチから新しいブランチを作成する (`git checkout -b feature/...`)
  - ブランチ名はConventional Branchに従う
  - 作業完了後、PRを作成する前にmainブランチの最新の変更を取り込む

## 関連Issue
Closes #5

## 補足
この手順により、常に最新のコードベースから開発を開始でき、コンフリクトのリスクを最小限に抑えることができます。